### PR TITLE
fix: Release PRs now opened by github-actions[bot]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,5 +16,3 @@ jobs:
       name: release-please
     steps:
       - uses: googleapis/release-please-action@v4
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
* I think it's because it was using my PAT and not the default runner one; sadly, this means we'll have to trigger CI on release PRs manually