### PR TITLE
fix: Manually set initial release version as v0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,6 +17,7 @@
     }
   },
   "pull-request-title-pattern": "chore: Release ${version}",
+  "release-as": "0.1",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
It seems that release-please defaulted to making a v1.0.0 release, but we want the first release to be v0.1. We're going to have to remember to remove this after merge.