### PR TITLE
ci(lint): Install nightly `rustfmt`

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -22,7 +22,10 @@ jobs:
           version: 1.0
       - name: Rust Caching
         uses: Swatinem/rust-cache@v2
+      - name: Install nightly rustfmt
+        # https://stegosaurusdormant.com/rustfmt-nightly/
+        run: rustup toolchain install nightly --allow-downgrade -c rustfmt
       - name: Lint
-        run: cargo clippy
+        run: cargo clippy --all --all-targets -- --deny warnings
       - name: Check formatting
-        run: cargo fmt --check
+        run: cargo +nightly fmt --check


### PR DESCRIPTION
Closes #8:
- Forces `clippy` lints to produce no warnings
- Installs nightly `rustfmt`