### PR TITLE
refactor(chat, server): Consistent server logging

### DIFF
--- a/client-connect/examples/simple_client.rs
+++ b/client-connect/examples/simple_client.rs
@@ -19,10 +19,10 @@ async fn main() -> ClientConnectionResult<()> {
         if line.is_empty() {
             break;
         }
-        tx.send(comms::ClientMessage::Append(comms::AppendChatEntry {
+        tx.send(comms::ClientMessage::Post {
             username: username.clone(),
             content: line,
-        }))
+        })
         .expect("todo");
     }
 

--- a/client-tui/src/app.rs
+++ b/client-tui/src/app.rs
@@ -411,10 +411,10 @@ impl App {
         let trimmed = self.input.trim();
         if !trimmed.is_empty() {
             self.tx
-                .send(comms::ClientMessage::Append(comms::AppendChatEntry {
+                .send(comms::ClientMessage::Post {
                     username: "me".to_string(),
                     content: trimmed.to_string(),
-                }))
+                })
                 .expect("channel closed on server");
         }
         self.input.clear();

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -18,16 +18,12 @@ pub trait Codable {
     }
 }
 
-// TODO: get rid of this
-#[derive(Debug, Serialize, Deserialize)]
-pub struct AppendChatEntry {
-    pub username: String,
-    pub content: String,
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
-    Append(AppendChatEntry),
+    Post {
+        username: String,
+        content: String,
+    },
     Request {
         count: usize,
         up_to_slot_number: Option<usize>,

--- a/scripts/local_server.sh
+++ b/scripts/local_server.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cargo run --features local --bin server 127.0.0.1:12345
+LOG=info cargo run --features local --bin server 127.0.0.1:12345


### PR DESCRIPTION
Closes #41:

- Removes `AppendChatEntry`
- Logs in server with`env_logger`