### PR TITLE
chore(protocol): Use JSON over bincode for passing data over websockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,15 +407,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,9 +1127,9 @@ dependencies = [
 name = "comms"
 version = "0.1.0"
 dependencies = [
- "bincode",
  "chat",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ rustls-webpki = "0.102.8"
 
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.134"
-bincode = "1.3.3"
 
 syn = { version = "2.0.90", features = ["visit", "full"] }
 quote = "1.0.37"

--- a/client-connect/src/lib.rs
+++ b/client-connect/src/lib.rs
@@ -23,7 +23,7 @@ pub enum ClientConnectionError {
     },
     WebSocketFailure(tungstenite::Error),
     UnexpectedWebSocketMessage(Message),
-    MalformedServerMessage(Message, comms::CodingErrorKind),
+    MalformedServerMessage(Message, comms::CodingError),
 }
 
 impl fmt::Display for ClientConnectionError {
@@ -155,7 +155,7 @@ async fn client_actor(
                             .map_err(|coding_error| {
                                 ClientConnectionError::MalformedServerMessage(
                                     message,
-                                    *coding_error,
+                                    coding_error,
                                 )
                             });
                         user_tx.send(server_message).expect(

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -9,4 +9,4 @@ edition.workspace = true
 [dependencies]
 chat.workspace = true
 serde.workspace = true
-bincode.workspace = true
+serde_json.workspace = true

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -1,20 +1,20 @@
-pub use bincode::{Error as CodingError, ErrorKind as CodingErrorKind};
 use chat::Entry;
 use serde::{Deserialize, Serialize};
+pub use serde_json::Error as CodingError;
 
 pub trait Codable {
     fn to_bytes(&self) -> Vec<u8>
     where
         Self: Serialize,
     {
-        bincode::serialize(self).expect("failed to serialize data")
+        serde_json::to_vec(self).expect("failed to serialize data")
     }
 
     fn try_from_bytes<'a>(bytes: &'a [u8]) -> Result<Self, CodingError>
     where
         Self: Deserialize<'a>,
     {
-        bincode::deserialize(bytes)
+        serde_json::from_slice(bytes)
     }
 }
 


### PR DESCRIPTION
- Switches from `bincode` to `serde_json` so @feverdreme can communicate with the server without needing a scuffed Rust RPC setup