### PR TITLE
feat(protocol): Tag server entries reply with client id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,6 +1128,7 @@ name = "comms"
 version = "0.1.0"
 dependencies = [
  "chat",
+ "chrono",
  "serde",
  "serde_json",
 ]

--- a/client-connect/examples/simple_client.rs
+++ b/client-connect/examples/simple_client.rs
@@ -37,7 +37,10 @@ async fn main() -> ClientConnectionResult<()> {
                         chat_log_entry.text_content()
                     );
                 }
-                comms::ServerMessage::EntryRange(entries) => {
+                comms::ServerMessage::EntryRange {
+                    client_id: _,
+                    entries,
+                } => {
                     println!("got entry range: {:?}", entries);
                 }
             }

--- a/client-tui/src/app.rs
+++ b/client-tui/src/app.rs
@@ -606,6 +606,7 @@ impl App {
         if self.messages_cursor == 0 {
             self.tx
                 .send(comms::ClientMessage::Request {
+                    client_id: comms::ClientId::unique_per_client(),
                     count: 50,
                     up_to_slot_number: Some(
                         messages

--- a/client-tui/src/app.rs
+++ b/client-tui/src/app.rs
@@ -606,7 +606,7 @@ impl App {
         if self.messages_cursor == 0 {
             self.tx
                 .send(comms::ClientMessage::Request {
-                    client_id: comms::ClientId::unique_per_client(),
+                    client_id: comms::ClientId::new_unique_per_client(),
                     count: 50,
                     up_to_slot_number: Some(
                         messages

--- a/client-tui/src/main.rs
+++ b/client-tui/src/main.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), io::Error> {
     let app_messages = messages.clone();
 
     tx.send(comms::ClientMessage::Request {
+        client_id: comms::ClientId::unique_per_client(),
         count: 50,
         up_to_slot_number: None,
     })
@@ -34,7 +35,10 @@ async fn main() -> Result<(), io::Error> {
                         break;
                     }
                 },
-                comms::ServerMessage::EntryRange(entries) => {
+                comms::ServerMessage::EntryRange {
+                    client_id: _,
+                    entries,
+                } => {
                     if !entries.is_empty() {
                         // since we don't have to worry about updates until
                         // v0.2, this is going to be

--- a/client-tui/src/main.rs
+++ b/client-tui/src/main.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), io::Error> {
     let app_messages = messages.clone();
 
     tx.send(comms::ClientMessage::Request {
-        client_id: comms::ClientId::unique_per_client(),
+        client_id: comms::ClientId::new_unique_per_client(),
         count: 50,
         up_to_slot_number: None,
     })

--- a/comms/Cargo.toml
+++ b/comms/Cargo.toml
@@ -10,3 +10,4 @@ edition.workspace = true
 chat.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+chrono.workspace = true

--- a/comms/src/lib.rs
+++ b/comms/src/lib.rs
@@ -1,4 +1,5 @@
 use chat::Entry;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 pub use serde_json::Error as CodingError;
 
@@ -18,6 +19,22 @@ pub trait Codable {
     }
 }
 
+/// Opaque unique-per-client identifier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientId {
+    timestamp: DateTime<Utc>,
+}
+
+impl ClientId {
+    /// Guaranteed to be unique for each client but not necessarily between
+    /// clients.
+    pub fn new_unique_per_client() -> Self {
+        Self {
+            timestamp: Utc::now(),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ClientMessage {
     Post {
@@ -25,6 +42,7 @@ pub enum ClientMessage {
         content: String,
     },
     Request {
+        client_id: ClientId,
         count: usize,
         up_to_slot_number: Option<usize>,
     },
@@ -35,7 +53,10 @@ impl Codable for ClientMessage {}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ServerMessage {
     NewEntry(Entry),
-    EntryRange(Vec<chat::Entry>),
+    EntryRange {
+        client_id: ClientId,
+        entries: Vec<chat::Entry>,
+    },
 }
 
 impl Codable for ServerMessage {}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -166,12 +166,14 @@ async fn main() -> Result<(), Error> {
                 }
             }
             comms::ClientMessage::Request {
+                client_id,
                 count,
                 up_to_slot_number,
             } => {
                 let entries = fake_chat_log.entries(count, up_to_slot_number);
-                sessions.read().await[&sender]
-                    .send(comms::ServerMessage::EntryRange(entries));
+                sessions.read().await[&sender].send(
+                    comms::ServerMessage::EntryRange { client_id, entries },
+                );
             }
         }
     }
@@ -254,16 +256,16 @@ async fn new_client_connection(
                                     match comms::ClientMessage::try_from_bytes(
                                         &message_bytes,
                                     ) {
-                                        Ok(client_request) => {
+                                        Ok(client_message) => {
                                             log::info!(
                                             "Received {:?} from client address {}",
-                                            client_request,
+                                           client_message ,
                                             client_address
                                         );
                                             message_tx
                                             .send((
                                                 client_address,
-                                                client_request,
+                                                client_message,
                                             ))
                                             .expect("Failed to queue client message for processing");
                                         }


### PR DESCRIPTION
- Adds an opaque, unique-per-client, id to explicit request/reply communication between clients and server